### PR TITLE
Fix configuration setup

### DIFF
--- a/tempest_horizon/config.py
+++ b/tempest_horizon/config.py
@@ -24,3 +24,7 @@ DashboardGroup = [
                help="Login page for the dashboard",
                deprecated_for_removal=True),
 ]
+
+service_opt = cfg.BoolOpt(
+    'horizon', default=True,
+    help="Whether or not Horizon is expected to be available")

--- a/tempest_horizon/plugin.py
+++ b/tempest_horizon/plugin.py
@@ -29,7 +29,10 @@ class HorizonTempestPlugin(plugins.TempestPlugin):
     def register_opts(self, conf):
         if 'dashboard' not in conf:
             config.register_opt_group(conf, dashboard_config.dashboard_group,
-                                      dashboard_config.BotoGroup)
+                                      dashboard_config.DashboardGroup)
+        if not getattr(conf.service_available, 'horizon'):
+            conf.register_opt(dashboard_config.service_opt,
+                              group='service_available')
 
     def get_opt_lists(self):
         return [('dashboard', config.DashboardGroup)]


### PR DESCRIPTION
This commit fixes some issues with configuration setup in the plugin.
Firstly, it adds the service available option which was missing from
the plugin. (this opt will be removed from tempest when this lands in
openstack) This also fixes the variable name used for registering the
plugins which was previously incorrectly using BotoGroup.
